### PR TITLE
Making the extension civicrm 4.6 compatible

### DIFF
--- a/CRM/Gdpr/Form/Forgetme.php
+++ b/CRM/Gdpr/Form/Forgetme.php
@@ -23,7 +23,7 @@ class CRM_Gdpr_Form_Forgetme extends CRM_Core_Form {
 
     // <!-- To DO - check permission -->
 
-    $this->_contactId = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
+    $this->_contactID = CRM_Utils_Request::retrieve('cid', 'Positive', $this, TRUE);
   }
 
   public function buildQuickForm() {
@@ -46,15 +46,15 @@ class CRM_Gdpr_Form_Forgetme extends CRM_Core_Form {
 
   public function postProcess() {
 
-    if (!$this->_contactId) {
+    if (!$this->_contactID) {
       CRM_Core_Error::fatal(ts("Something went wrong. Please contact Admin."));
     }
 
     // Remove all the linked relationship records of this contact
     $params = array(
       'sequential' => 1,
-      'contact_id_a' => $this->_contactId,
-      'contact_id_b' => $this->_contactId,
+      'contact_id_a' => $this->_contactID,
+      'contact_id_b' => $this->_contactID,
       'options' => array('or' => array(array("contact_id_a", "contact_id_b"))),
     );
     self::removeEntityRecords('Relationship', $params);
@@ -62,35 +62,35 @@ class CRM_Gdpr_Form_Forgetme extends CRM_Core_Form {
     // Remove all the address records of this contact
     $params = array(
       'sequential' => 1,
-      'contact_id' => $this->_contactId,
+      'contact_id' => $this->_contactID,
     );
     self::removeEntityRecords('Address', $params);
 
     // Remove all the email records of this contact
     $params = array(
       'sequential' => 1,
-      'contact_id' => $this->_contactId,
+      'contact_id' => $this->_contactID,
     );
     self::removeEntityRecords('Email', $params);
 
     // Remove all the phone records of this contact
     $params = array(
       'sequential' => 1,
-      'contact_id' => $this->_contactId,
+      'contact_id' => $this->_contactID,
     );
     self::removeEntityRecords('Phone', $params);
 
     // Remove all the website records of this contact
     $params = array(
       'sequential' => 1,
-      'contact_id' => $this->_contactId,
+      'contact_id' => $this->_contactID,
     );
     self::removeEntityRecords('Website', $params);
 
     // Remove all the IM records of this contact
     $params = array(
       'sequential' => 1,
-      'contact_id' => $this->_contactId,
+      'contact_id' => $this->_contactID,
     );
     self::removeEntityRecords('Im', $params);
 
@@ -131,10 +131,10 @@ class CRM_Gdpr_Form_Forgetme extends CRM_Core_Form {
   }
 
   private function makeContactAnonymous() {
-    if (!$this->_contactId) {
+    if (!$this->_contactID) {
       CRM_Core_Error::fatal(ts("Something went wrong. Please contact Admin."));
     }
-    $params = array('id' => $this->_contactId); 
+    $params = array('id' => $this->_contactID);
     // Update contact Record
     $updateResult = CRM_Gdpr_Utils::CiviCRMAPIWrapper('Contact', 'anonymize', $params);
 

--- a/CRM/Gdpr/Page/AJAX.php
+++ b/CRM/Gdpr/Page/AJAX.php
@@ -208,7 +208,7 @@ TABLE;
       //'activity_date_time',
     );
 
-    header("Content-Type: application/jsons");
+    header("Content-Type: application/json");
     echo CRM_Utils_JSON::encodeDataTableSelector($contactList, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);
     CRM_Utils_System::civiExit();
   }

--- a/CRM/Gdpr/Page/AJAX.php
+++ b/CRM/Gdpr/Page/AJAX.php
@@ -208,7 +208,7 @@ TABLE;
       //'activity_date_time',
     );
 
-    CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
+    header("Content-Type: application/jsons");
     echo CRM_Utils_JSON::encodeDataTableSelector($contactList, $sEcho, $iTotal, $iFilteredTotal, $selectorElements);
     CRM_Utils_System::civiExit();
   }

--- a/CRM/Gdpr/Utils.php
+++ b/CRM/Gdpr/Utils.php
@@ -414,11 +414,22 @@ WHERE url.time_stamp > '{$date}'";
     );
 
     // Loop through fields and set them empty
+    $isCiviCRMVersion47 = _gdpr_isCiviCRMVersion47();
     foreach ($fields as $key => $field) {
       //Fix me : skipping if not a core field. We may need to clear the custom fields later
-      if ( !array_key_exists('is_core_field', $field) || $field['is_core_field'] != 1 ) {
-        continue;
+      if ($isCiviCRMVersion47) {
+        if ( !array_key_exists('is_core_field', $field) || $field['is_core_field'] != 1 ) {
+          continue;
+        }
+      } else {
+        // is_core_field is not supported in 4.6, so we only anonymize fields with
+        // 'where' clause that start with 'civicrm_contact.' since they are usually
+        // the core civi fields.
+        if ( !array_key_exists('where', $field) || strpos($field['where'], 'civicrm_contact.') != 0) {
+          continue;
+        }
       }
+
 
       $fieldName = $field['name'];
       $params[$fieldName] = '';

--- a/gdpr.php
+++ b/gdpr.php
@@ -252,16 +252,39 @@ function gdpr_civicrm_tabset($tabsetName, &$tabs, $context) {
   //check if the tabset is Contact Summary Page
   if ($tabsetName == 'civicrm/contact/view') {
     $contactId = $context['contact_id'];
-    $url = CRM_Utils_System::url('civicrm/gdpr/view/tab', "reset=1&cid={$contactId}");
-    $tabs[] = array( 'id'    => 'gdprTab',
-      'url'   => $url,
-      'title' => ts('GDPR'),
-      'weight' => 300,
-      'class'  => 'livePage',
-    );
+    _gdpr_addGDPRTab($tabs, $contactId);
   }
 }
 
+/*
+ * Add a tab to show group subscription
+ */
+function gdpr_civicrm_tabs(&$tabs, $contactID) {
+  if (_gdpr_isCiviCRMVersion47()) {
+    return;
+  }
+
+  _gdpr_addGDPRTab($tabs, $contactID);
+}
+
+function _gdpr_addGDPRTab(&$tabs, $contactID) {
+  $url = CRM_Utils_System::url('civicrm/gdpr/view/tab', "reset=1&cid={$contactID}");
+  $tabs[] = array( 'id'    => 'gdprTab',
+    'url'   => $url,
+    'title' => ts('GDPR'),
+    'weight' => 300,
+    'class'  => 'livePage',
+  );
+}
+
+/**
+ * Checks if civicrm version is 4.7
+ *
+ * @return mixed
+ */
+function _gdpr_isCiviCRMVersion47(){
+  return version_compare(CRM_Utils_System::version(), '4.7', '>');
+}
 /**
  * Add navigation for GDPR Dashboard
  *

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,7 @@
   <version>1.0</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>4.7</ver>
+    <ver>4.6, 4.7</ver>
   </compatibility>
   <comments>This extension is under active development</comments>
   <civix>

--- a/info.xml
+++ b/info.xml
@@ -18,7 +18,8 @@
   <version>1.0</version>
   <develStage>beta</develStage>
   <compatibility>
-    <ver>4.6, 4.7</ver>
+    <ver>4.6</ver>
+    <ver>4.7</ver>
   </compatibility>
   <comments>This extension is under active development</comments>
   <civix>

--- a/xml/CustomGroupData.xml
+++ b/xml/CustomGroupData.xml
@@ -17,7 +17,6 @@
       <table_name>civicrm_value_sla_acceptance_4</table_name>
       <is_multiple>0</is_multiple>
       <collapse_adv_display>0</collapse_adv_display>
-      <created_date>2017-12-11 11:43:54</created_date>
       <is_reserved>0</is_reserved>
       <is_public>1</is_public>
     </CustomGroup>


### PR DESCRIPTION
Some changes to make the extension civicrm 4.6 compatible : 

1- Replacing the call to : 

```php
CRM_Utils_System::setHttpHeader('Content-Type', 'application/json');
```
which only exist on civicrm 4.7 to : 

```php
 header("Content-Type: application/jsons");
```

2- Removing the <create_date> field from **xml/CustomGroupData.xml** since it was causing problems on installation and it is not an important field to be included anyway.

3- This is issue for both 4.7 and 4.6, inside **CRM_Gdpr_Form_Forgetme** class this propery is defined : 

```php
  /**
   * Contact ID.
   *
   * @var int
   */
  protected $_contactID = NULL;
```

but the class itself was using this instead : 

```php
$this->_contactId 
```

so I fixed that.



4- I also added implementation for both hook_civicrm_tabs and hook_civicrm_tabset hooks to ensure that the tab appear for both civicrm 4.7 and 4.6.

5- Contacts anonmization was not working on 4.6, the current code use **is_core_field** field which is only available on 4.7, so I've added a version check there and if civi 4.6 is used then it will use "where" field instead and ensure that the where field start with "civicrm_contact." since core fields usually start with that.