### PR TITLE
PHP warning fixes

### DIFF
--- a/CRM/Gdpr/Hook.php
+++ b/CRM/Gdpr/Hook.php
@@ -1,0 +1,48 @@
+<?php
+/*--------------------------------------------------------------------+
+ | CiviCRM version 4.7                                                |
++--------------------------------------------------------------------+
+ | Copyright CiviCRM LLC (c) 2004-2017                                |
++--------------------------------------------------------------------+
+ | This file is a part of CiviCRM.                                    |
+ |                                                                    |
+ | CiviCRM is free software; you can copy, modify, and distribute it  |
+ | under the terms of the GNU Affero General Public License           |
+ | Version 3, 19 November 2007 and the CiviCRM Licensing Exception.   |
+ |                                                                    |
+ | CiviCRM is distributed in the hope that it will be useful, but     |
+ | WITHOUT ANY WARRANTY; without even the implied warranty of         |
+ | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.               |
+ | See the GNU Affero General Public License for more details.        |
+ |                                                                    |
+ | You should have received a copy of the GNU Affero General Public   |
+ | License and the CiviCRM Licensing Exception along                  |
+ | with this program; if not, contact CiviCRM LLC                     |
+ | at info[AT]civicrm[DOT]org. If you have questions about the        |
+ | GNU Affero General Public License or the licensing of CiviCRM,     |
+ | see the CiviCRM license FAQ at http://civicrm.org/licensing        |
+ +-------------------------------------------------------------------*/
+
+/**
+ * Class CRM_Gdpr_Hook
+ *
+ * This class implements hooks for Gdpr extension
+ */
+class CRM_Gdpr_Hook {
+
+  /**
+   * This hook allows to alter contact params when anonymizing contact
+   *
+   * @param array $params contact params
+   *
+   * @access public
+   *
+   * @return mixed
+   */
+  static function alterAnonymizeContactParams(&$params) {
+    return CRM_Utils_Hook::singleton()
+      ->invoke(1, $params, CRM_Utils_Hook::$_nullObject, CRM_Utils_Hook::$_nullObject, CRM_Utils_Hook::$_nullObject,
+        CRM_Utils_Hook::$_nullObject, CRM_Utils_Hook::$_nullObject, 'civicrm_gdpr_alterAnonymizeContactParams');
+  }
+
+}

--- a/CRM/Gdpr/Page/AJAX.php
+++ b/CRM/Gdpr/Page/AJAX.php
@@ -43,7 +43,7 @@ class CRM_Gdpr_Page_AJAX {
   /**
    * Function to get address log for a contact
    */
-	function get_address_logs($contactId){
+  public static function get_address_logs($contactId){
     
     $aGetMemberships =array();
 
@@ -82,7 +82,7 @@ ORDER BY lca.log_date DESC";
     return $aGetMemberships;
   }
   
-  function get_address_history_table( $data ){
+  public static function get_address_history_table( $data ){
     if(empty($data)){
       return null;
     }

--- a/CRM/Gdpr/Utils.php
+++ b/CRM/Gdpr/Utils.php
@@ -434,6 +434,10 @@ WHERE url.time_stamp > '{$date}'";
     if (!empty($settings['forgetme_name'])) {
       $params['last_name'] = $settings['forgetme_name'];
     }
+
+    // Allow params to be modified via hook
+    CRM_Gdpr_Hook::alterAnonymizeContactParams($params);
+
     $updateResult = CRM_Gdpr_Utils::CiviCRMAPIWrapper('Contact', 'create', $params);
     $associatedResult = self::deleteContactAssociatedData($contactId, array(
       'Email', 


### PR DESCRIPTION
1. Fixed PHP warnings
2. Added new hook to be called before the contact is anonymized

**Hook Definition:**
hook_civicrm_gdpr_alterAnonymizeContactParams(&$params)

**Hook Parameters:**
array $params - contact parameters that were sent into the calling function

**Example:**
$params = Array
```
(
    [sequential] => 1
    [id] => 264210
    [last_name] => Anonymous
)
```