### PR TITLE
Change permissions

### DIFF
--- a/gdpr.php
+++ b/gdpr.php
@@ -447,3 +447,21 @@ function gdpr_civicrm_summaryActions( &$actions, $contactID ) {
     'href' => CRM_Gdpr_CommunicationsPreferences_Utils::getCommPreferenceURLForContact($contactID, TRUE),
   );  
 }
+
+function gdpr_civicrm_permission(&$permissions) {
+  $prefix = ts('GDPR') . ': ';
+  $version = CRM_Utils_System::version();
+  if (version_compare($version, '4.6.1') >= 0) {
+    $permissions += array(
+      'forget contact' => array(
+        $prefix . ts('Forget Contact'),
+        ts('Grants the necessary permissions to anonymize a contact'),
+      ),
+    );
+  }
+  else {
+    $permissions += array(
+      'forget contact' => $prefix . ts('Forget Contact'),
+    );
+  }
+}

--- a/gdpr.php
+++ b/gdpr.php
@@ -400,7 +400,7 @@ function gdpr_civicrm_navigationMenu( &$params ) {
         'label'      => 'GDPR Dashboard',
         'name'       => 'GDPR Dashboard',
         'url'        => 'civicrm/gdpr/dashboard?reset=1',
-        'permission' => 'access CiviCRM',
+        'permission' => 'access GDPR',
         'operator'   => NULL,
         'separator'  => FALSE,
         'parentID'   => $contactsMenuId,
@@ -453,15 +453,26 @@ function gdpr_civicrm_permission(&$permissions) {
   $version = CRM_Utils_System::version();
   if (version_compare($version, '4.6.1') >= 0) {
     $permissions += array(
+      'access GDPR' => array(
+        $prefix . ts('access GDPR'),
+        ts('View GDPR related information'),
+      ),
       'forget contact' => array(
-        $prefix . ts('Forget Contact'),
-        ts('Grants the necessary permissions to anonymize a contact'),
+        $prefix . ts('forget contact'),
+        ts('Anonymize contacts'),
+      ),
+      'administer GDPR' => array(
+        $prefix . ts('administer GDPR'),
+        ts('Manage GDPR settings'),
       ),
     );
   }
   else {
     $permissions += array(
-      'forget contact' => $prefix . ts('Forget Contact'),
+      'access GDPR' => $prefix . ts('access GDPR'),
+      'forget contact' => $prefix . ts('forget contact'),
+      'administer GDPR' => $prefix . ts('administer GDPR'),
     );
   }
 }
+

--- a/gdpr.php
+++ b/gdpr.php
@@ -454,19 +454,14 @@ function gdpr_civicrm_permission(&$permissions) {
   if (version_compare($version, '4.6.1') >= 0) {
     $permissions += array(
       'forget contact' => array(
-        $prefix . ts('forget contact'),
-        ts('Anonymize contacts'),
-      ),
-      'access GDPR' => array(
-        $prefix . ts('access GDPR'),
-        ts('Access GDPR related information'),
+        $prefix . ts('Forget Contact'),
+        ts('Grants the necessary permissions to anonymize a contact'),
       ),
     );
   }
   else {
     $permissions += array(
-      'forget contact' => $prefix . ts('forget contact'),
-      'access GDPR' => $prefix . ts('access GDPR'),
+      'forget contact' => $prefix . ts('Forget Contact'),
     );
   }
 }

--- a/gdpr.php
+++ b/gdpr.php
@@ -454,14 +454,19 @@ function gdpr_civicrm_permission(&$permissions) {
   if (version_compare($version, '4.6.1') >= 0) {
     $permissions += array(
       'forget contact' => array(
-        $prefix . ts('Forget Contact'),
-        ts('Grants the necessary permissions to anonymize a contact'),
+        $prefix . ts('forget contact'),
+        ts('Anonymize contacts'),
+      ),
+      'access GDPR' => array(
+        $prefix . ts('access GDPR'),
+        ts('Access GDPR related information'),
       ),
     );
   }
   else {
     $permissions += array(
-      'forget contact' => $prefix . ts('Forget Contact'),
+      'forget contact' => $prefix . ts('forget contact'),
+      'access GDPR' => $prefix . ts('access GDPR'),
     );
   }
 }

--- a/templates/CRM/Gdpr/Page/Tab.tpl
+++ b/templates/CRM/Gdpr/Page/Tab.tpl
@@ -1,9 +1,11 @@
 <!-- To DO - check permission before displaying the button -->
+{if $crmPermissions->check('forget contact')}
 <div class="action-link">
   {capture assign=forgetMeURL}{crmURL p="civicrm/gdpr/forgetme" q="reset=1&cid=`$contactId`"}{/capture}
   <a href="{$forgetMeURL}" class="button small-popup"><span><i class="crm-i fa-chain-broken"></i> {ts}Forget Me{/ts}</span></a>
   <br/><br/>
 </div>
+{/if}
 
 <h3>Summary</h3>
 

--- a/templates/CRM/Gdpr/Page/Tab.tpl
+++ b/templates/CRM/Gdpr/Page/Tab.tpl
@@ -1,4 +1,3 @@
-<!-- To DO - check permission before displaying the button -->
 {if $crmPermissions->check('forget contact')}
 <div class="action-link">
   {capture assign=forgetMeURL}{crmURL p="civicrm/gdpr/forgetme" q="reset=1&cid=`$contactId`"}{/capture}

--- a/xml/Menu/gdpr.xml
+++ b/xml/Menu/gdpr.xml
@@ -4,13 +4,13 @@
     <path>civicrm/gdpr/view/tab</path>
     <page_callback>CRM_Gdpr_Page_Tab</page_callback>
     <title>GDPR Tab</title>
-    <access_arguments>access GDPR</access_arguments>
+    <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/dashboard</path>
     <page_callback>CRM_Gdpr_Page_Dashboard</page_callback>
     <title>GDPR - Dashboard</title>
-    <access_arguments>access GDPR</access_arguments>
+    <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/activitycontact</path>
@@ -46,13 +46,13 @@
     <path>civicrm/event/manage/terms_conditions</path>
     <page_callback>CRM_Gdpr_Form_ManageEvent_TermsAndConditions</page_callback>
     <title>ManageEvent_TermsAndConditions</title>
-    <access_arguments>access GDPR</access_arguments>
+    <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/comms-prefs/settings</path>
     <page_callback>CRM_Gdpr_Form_CommunicationsPreferences</page_callback>
     <title>CommunicationsPreferences</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>access CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/comms-prefs/update</path>

--- a/xml/Menu/gdpr.xml
+++ b/xml/Menu/gdpr.xml
@@ -4,30 +4,30 @@
     <path>civicrm/gdpr/view/tab</path>
     <page_callback>CRM_Gdpr_Page_Tab</page_callback>
     <title>GDPR Tab</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access GDPR</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/dashboard</path>
     <page_callback>CRM_Gdpr_Page_Dashboard</page_callback>
     <title>GDPR - Dashboard</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access GDPR</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/activitycontact</path>
     <page_callback>CRM_Gdpr_Form_Activitycontact</page_callback>
     <title>GDPR - Contacts without Activities</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access GDPR</access_arguments>
   </item>
   <item>
     <path>civicrm/ajax/gdpractivitycontactlist</path>
     <page_callback>CRM_Gdpr_Page_AJAX::getGdprActivityContactList</page_callback>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access GDPR</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/settings</path>
     <page_callback>CRM_Gdpr_Form_Settings</page_callback>
     <title>GDPR Settings</title>
-    <access_arguments>administer CiviCRM</access_arguments>
+    <access_arguments>administer GDPR</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/forgetme</path>
@@ -52,7 +52,7 @@
     <path>civicrm/gdpr/comms-prefs/settings</path>
     <page_callback>CRM_Gdpr_Form_CommunicationsPreferences</page_callback>
     <title>CommunicationsPreferences</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>administer GDPR</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/comms-prefs/update</path>

--- a/xml/Menu/gdpr.xml
+++ b/xml/Menu/gdpr.xml
@@ -34,7 +34,7 @@
     <path_arguments>cid=%%cid%%</path_arguments>
     <page_callback>CRM_Gdpr_Form_Forgetme</page_callback>
     <title>Forgetme</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>forget contact</access_arguments>
   </item>
   <item>
     <path>civicrm/terms/accept</path>

--- a/xml/Menu/gdpr.xml
+++ b/xml/Menu/gdpr.xml
@@ -4,13 +4,13 @@
     <path>civicrm/gdpr/view/tab</path>
     <page_callback>CRM_Gdpr_Page_Tab</page_callback>
     <title>GDPR Tab</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access GDPR</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/dashboard</path>
     <page_callback>CRM_Gdpr_Page_Dashboard</page_callback>
     <title>GDPR - Dashboard</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access GDPR</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/activitycontact</path>
@@ -46,13 +46,13 @@
     <path>civicrm/event/manage/terms_conditions</path>
     <page_callback>CRM_Gdpr_Form_ManageEvent_TermsAndConditions</page_callback>
     <title>ManageEvent_TermsAndConditions</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>access GDPR</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/comms-prefs/settings</path>
     <page_callback>CRM_Gdpr_Form_CommunicationsPreferences</page_callback>
     <title>CommunicationsPreferences</title>
-    <access_arguments>access CiviCRM</access_arguments>
+    <access_arguments>administer CiviCRM</access_arguments>
   </item>
   <item>
     <path>civicrm/gdpr/comms-prefs/update</path>


### PR DESCRIPTION
I added three permissions:
- a permission to "forget a contact"
- a permission to access the GDPR Tab & Dashboard
- a permission to change settings

This way:
- Not every user who has access to CiviCRM can anonymize.
(Users who are allowed to view but not edit should not be allowed to anonymize everything)
- It's possible to hide the GDPR tab from some users if needed.
- Administering the settings can be done by a GDPR admin (e.g. the DPO), and not just a CiviCRM admin