### PR TITLE
civi4.6.11 or older version, activity API seems doesn't return right …

### DIFF
--- a/CRM/Gdpr/CommunicationsPreferences/Utils.php
+++ b/CRM/Gdpr/CommunicationsPreferences/Utils.php
@@ -205,7 +205,9 @@ class CRM_Gdpr_CommunicationsPreferences_Utils {
     $result = civicrm_api3('Activity', 'get', array(
       'sequential' => 1,
       'activity_type_id' => "Update_Communication_Preferences",
-      'source_contact_id' => $cid,
+      // 'source_contact_id' => $cid,
+      //MV: Civi Older version doesn't return api value using source_contact_id. if we add target_contact_id then BAO query include activity contact table and filter out using params
+      'target_contact_id' => $cid,      
       'options' => array('sort' => "id desc"),
     ));
     return !empty($result['values']) ? $result['values'][0] : $return;


### PR DESCRIPTION
…result filter by source_contact_id, expecting target_contact_id instead to get right activity details