### PR TITLE
Add 5.0 to info file for clarity

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -20,6 +20,7 @@
   <compatibility>
     <ver>4.6</ver>
     <ver>4.7</ver>
+    <ver>5.0</ver>
   </compatibility>
   <comments>This extension is under active development, with the up and coming GDPR implementation date of the 25th of May we're expecting a lot of activity on the extension.</comments>
   <civix>


### PR DESCRIPTION
Info about versions https://lab.civicrm.org/dev/release/issues/1#note_2843

In the 4.x series, <ver> tags mean the same as today. (Exact-match to version. An extension declaring ``<ver>4.6</ver>`` is not displayed for download on 4.7.)
In the 5.x series, ``<ver>`` tags imply forward compatibility. (An extension declaring`` <ver>5.2</ver>`` is displayed on 5.2, 5.3, etc. But not on 5.0.)
To bridge them, 4.7 is forward compatible with 5.0. (An extension declaring ``<ver>4.7</ver>`` is displayed on 4.7, 5.0, 5.1, etc.)
As today, a consumer sees the newest extensions that are compatible with their version.