### PR TITLE
Remove 'administer GDPR' dependancy on 'forget contact'

### DIFF
--- a/CRM/Gdpr/Page/Tab.php
+++ b/CRM/Gdpr/Page/Tab.php
@@ -18,10 +18,6 @@ class CRM_Gdpr_Page_Tab extends CRM_Core_Page {
     $summary['data_policy'] = $this->getDataPolicyDetails($contactId);
     $this->assign('summary', $summary);
 
-    // Is current user an admin?
-    $isGdprAdmin = CRM_Core_Permission::check('administer GDPR');
-    $this->assign('isGdprAdmin', $isGdprAdmin);
-
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.vedaconsulting.gdpr', 'css/gdpr.css');
 
     parent::run();

--- a/templates/CRM/Gdpr/Page/Tab.tpl
+++ b/templates/CRM/Gdpr/Page/Tab.tpl
@@ -1,10 +1,8 @@
 {crmScope extensionKey='uk.co.vedaconsulting.gdpr'}
 {if $crmPermissions->check('forget contact')}
 <div class="action-link">
-  {if $isGdprAdmin }
     {capture assign=forgetMeURL}{crmURL p="civicrm/gdpr/forgetme" q="reset=1&cid=`$contactId`"}{/capture}
   <a href="{$forgetMeURL}" class="button small-popup"><span><i class="crm-i fa-chain-broken"></i> {ts}Forget Me{/ts}</span></a>
-  {/if}
   <br/><br/>
 </div>
 {/if}


### PR DESCRIPTION
Allows delegation of 'forget contact' without giving use full administer GDPR permissions

Fix for #114 