### PR TITLE
#121 - Inherit profile's duplicate match option

### DIFF
--- a/CRM/Gdpr/Form/UpdatePreference.php
+++ b/CRM/Gdpr/Form/UpdatePreference.php
@@ -210,7 +210,7 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
       $dao = new CRM_Core_DAO_UFGroup();
       $dao->id = $id;
       if ($dao->find(TRUE)) {
-        $this->_isUpdateDupe = 1;
+        $this->_isUpdateDupe = $dao->is_update_dupe; // Profile duplicate match option
         // $this->_isUpdateDupe = $dao->is_update_dupe;
         $this->_isAddCaptcha = $dao->add_captcha;
         $this->_ufGroup = (array) $dao;


### PR DESCRIPTION
Inherit profile's duplicate match option instead of hardcoded update matching contact option. This will avoid contact record being overwritten for anonymous users.

Fix for Issue [#121](https://github.com/veda-consulting/uk.co.vedaconsulting.gdpr/issues/121)