### PR TITLE
Change Post to Postal Mail

### DIFF
--- a/CRM/Gdpr/CommunicationsPreferences/Utils.php
+++ b/CRM/Gdpr/CommunicationsPreferences/Utils.php
@@ -221,7 +221,7 @@ class CRM_Gdpr_CommunicationsPreferences_Utils {
     return $channels = array(
       'email' => E::ts('Email'),
       'phone' => E::ts('Phone'),
-      'post' => E::ts('Post'),
+      'post' => E::ts('Postal Mail'),
       'sms' => E::ts('SMS'),
     );
   }


### PR DESCRIPTION
This will make it conform to label in CiviCRM, and get rid of confusing UK term without needing to have translation file.