### PR TITLE
Log exception message, not the exception

### DIFF
--- a/CRM/Gdpr/Utils.php
+++ b/CRM/Gdpr/Utils.php
@@ -24,7 +24,7 @@ class CRM_Gdpr_Utils {
     }
     catch (Exception $e) {
       CRM_Core_Error::debug_log_message('CiviCRM API Call Failed');
-      CRM_Core_Error::debug_var('CiviCRM API Call Error', $e);
+      CRM_Core_Error::debug_var('CiviCRM API Call Error', $e->getMessage());
       return;
     }
 


### PR DESCRIPTION
I get out-of-memory errors when API calls fail in this extension.  I think we want to return the exception message, not the exception object itself.