### PR TITLE
CIVICRM-1141 Fix Wordpress text appears int the middle of the GDPR

### DIFF
--- a/templates/CRM/Gdpr/Form/CommunicationsPreferences.tpl
+++ b/templates/CRM/Gdpr/Form/CommunicationsPreferences.tpl
@@ -123,7 +123,6 @@
     </div>
     <div class="clear"></div>
   </div> {* end Completion block *}
- </div>
   <h3> {ts}Event & Contribution thank you page{/ts} </h3>
   <div class="crm-block crm-form-block crm-gdpr-comms-prefs-form-block">
     <div class="help">{ts}<p>Allows supporters set their preferences after registering for an event or making a contribution.</p><p>Note, to embed the Communcation Preferences form in thank-you pages, you need to give anonymous users the permission: <em>CiviCRM: access AJAX API</em>.</p>{/ts}</div>

--- a/templates/CRM/Gdpr/Form/Settings.tpl
+++ b/templates/CRM/Gdpr/Form/Settings.tpl
@@ -249,7 +249,7 @@
     </div>
 	</div>
 </div>
-</div>
+
 {* Terms and conditions for Events and Contribution Pages *}
 <h3>{ts}Terms &amp; Conditions: Events and Contribution Pages{/ts}</h3>
 <div class="crm-block crm-form-block crm-gdpr-settings-form-block">
@@ -311,7 +311,6 @@
 {include file="CRM/common/formButtons.tpl" location="bottom"}
 </div>
 
-</div>
 {literal}
 <script>
 (function($) {


### PR DESCRIPTION
Found bug - The "Created with WordPress" text appears in the middle of the GDPR settings page.
This is because there are two close </div> tags appear in the Settings.tpl without opening tags. 