### PR TITLE
Check if GDPR_Cancelled Membership Status already exists

### DIFF
--- a/CRM/Gdpr/Upgrader.php
+++ b/CRM/Gdpr/Upgrader.php
@@ -190,9 +190,16 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
 
 
   /**
-   * Example: Run an external SQL script when the module is uninstalled.
+   * Create 'GDPR Cancelled' membership status
    */
   private function createGDPRCancelledMembershipStatus() {
+    $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', [
+      'name' => "GDPR_Cancelled",
+    ]);
+    if ($result['count']) {
+      return ;
+    }
+
     // Get max weight for membership status
     $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', array(
       'sequential' => 1,


### PR DESCRIPTION
Function CRM_Gdpr_Upgrader::createGDPRCancelledMembershipStatus() is called during install and upgrade_1200. For new installation of extension second call (from upgrade_1200) invoke error because GDPR_Cancelled status already exists.