### PR TITLE
Fix php notices, cleanup comms preferences form

### DIFF
--- a/CRM/Gdpr/CommunicationsPreferences/Utils.php
+++ b/CRM/Gdpr/CommunicationsPreferences/Utils.php
@@ -27,7 +27,8 @@ class CRM_Gdpr_CommunicationsPreferences_Utils {
       'enable_groups' => 0,
       'groups_heading' => E::ts('Interest groups'),
       'groups_intro' => E::ts('We want to continue to keep you informed about our work. Opt-in to the groups that interest you.'),
-      'completion_message' => E::ts('Your communications preferences have been updated. Thank you.')
+      'completion_message' => E::ts('Your communications preferences have been updated. Thank you.'),
+      'add_captcha' => 0,
     );
 
     foreach (self::getGroups() as $group) {

--- a/CRM/Gdpr/Form/UpdatePreference.php
+++ b/CRM/Gdpr/Form/UpdatePreference.php
@@ -68,8 +68,7 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
     }
 
     //Include reCAPTCHA?
-    $addCaptcha = $this->commPrefSettings['add_captcha'];
-    if ($addCaptcha) {
+    if ($addCaptcha = $this->commPrefSettings['add_captcha']) {
       $captcha = CRM_Utils_ReCAPTCHA::singleton();
       $captcha->add($this);
       $this->assign('isCaptcha', TRUE);

--- a/templates/CRM/Gdpr/Form/UpdatePreference.tpl
+++ b/templates/CRM/Gdpr/Form/UpdatePreference.tpl
@@ -11,7 +11,7 @@
 		{/if}
 
 		{if !empty($form.activity_source)}
-		<fieldset>
+		<fieldset id="crm-communications-preferences-groups">
 			<div class="crm-section">
 				<div class="label">{$form.activity_source.label}</div>
 				<div class="content">{$form.activity_source.html}</div>
@@ -21,7 +21,7 @@
 
 		<!-- if any profile has configured -->
 		{if !empty($custom_pre)}
-		<fieldset>
+		<fieldset id="crm-communications-preferences-profile">
 		    <div class="crm-public-form-item crm-group custom_pre_profile-group">
 		    {include file="CRM/UF/Form/Block.tpl" fields=$custom_pre}
 		    </div>
@@ -29,8 +29,11 @@
 		{/if}
 
 		<!-- Channels fieldset section -->
-		<fieldset>
+		{if $channelEleNames}
+		<fieldset id="crm-communications-preferences-channels">
+			{if $channels_intro}
 			<legend>{$channels_intro}</legend>
+			{/if}
 			{foreach from=$channelEleNames item=elementName}
 			  <div class="crm-section">
 			    <div class="label">{$form.$elementName.label}</div>
@@ -39,14 +42,18 @@
 			  </div>
 			{/foreach}
 		</fieldset>
+		{/if}
 	</div>
 
 	<!-- Groups from settings -->
 	<div class="comm-pref-block groups-block">
 
+		{if $groupEleNames}
 		<!-- Groups Fieldset -->
-		<fieldset class="groups-fieldset">
+		<fieldset id="crm-communications-preferences-groups" class="groups-fieldset">
+			{if $groups_heading}
 			<legend>{$groups_heading}</legend>
+			{/if}
       {if $groups_intro}
       <div class="section-description">
         {ts}{$groups_intro}{/ts}
@@ -77,10 +84,11 @@
 			  </div>
 			{/foreach}
 		</fieldset>
+		{/if}
 
 	<div class="clear"></div>
 		<!-- GDPR Terms and conditions url link and checkbox -->
-    <fieldset class="data-policy-fieldset">
+    <fieldset id="crm-communications-preferences-datapolicy" class="data-policy-fieldset">
 		{if $isContactDueAcceptance}
       <div class="data-policy-intro section-sescription">
           {$tcIntro}


### PR DESCRIPTION
Fix some php notices and cleanup comms preferences form so it is easier to theme and empty sections are not rendered.