### PR TITLE
2.8

### DIFF
--- a/CRM/Gdpr/CommunicationsPreferences/Utils.php
+++ b/CRM/Gdpr/CommunicationsPreferences/Utils.php
@@ -27,7 +27,8 @@ class CRM_Gdpr_CommunicationsPreferences_Utils {
       'enable_groups' => 0,
       'groups_heading' => E::ts('Interest groups'),
       'groups_intro' => E::ts('We want to continue to keep you informed about our work. Opt-in to the groups that interest you.'),
-      'completion_message' => E::ts('Your communications preferences have been updated. Thank you.')
+      'completion_message' => E::ts('Your communications preferences have been updated. Thank you.'),
+      'add_captcha' => 0,
     );
 
     foreach (self::getGroups() as $group) {

--- a/CRM/Gdpr/Form/CommunicationsPreferences.php
+++ b/CRM/Gdpr/Form/CommunicationsPreferences.php
@@ -367,64 +367,6 @@ class CRM_Gdpr_Form_CommunicationsPreferences extends CRM_Core_Form {
 
   }
 
-  public function addRules() {
-    $this->addFormRule(array('CRM_Gdpr_Form_CommunicationsPreferences', 'validateRedirectUrl'));
-  }
-
-  /**
-   * Validation callback for completion redirect url.
-   */
-  public static function validateRedirectUrl($values) {
-    $errors = array();
-    if (!empty($values['completion_redirect'])) {
-      if (empty($values['completion_url'])) {
-        // This is okay, we will redirect to the home page.
-      }
-      else {
-        $url = $values['completion_url'];
-        $parsed_url = parse_url($url);
-        $base_url = CIVICRM_UF_BASEURL;
-        if (!empty($parsed_url['host']) && !empty($parsed_url['scheme'])) {
-          $full_url = $url;
-        }
-        else {
-          // Remove leading slash from base and trailing slash from path.
-          if (0 === strpos($url, '/')) {
-            $url = substr($url, 1);
-          }
-          $last_pos = strlen($base_url) -1;
-          if (strrpos($base_url, '/') === $last_pos) {
-            $base_url = substr($base_url, 0, $last_pos);
-          }
-          $full_url = $base_url . '/' . $url;
-        }
-
-        // We have been unable to construct a URL.
-        if (!$full_url) {
-          $errors['completion_url'] = E::ts('Invalid URL.');
-        }
-        elseif (function_exists('curl_init')) {
-          // Test if the url exists.
-          $ch  = curl_init();
-          curl_setopt($ch, CURLOPT_URL, $full_url);
-          curl_setopt($ch, CURLOPT_HEADER, TRUE);
-          curl_setopt($ch, CURLOPT_NOBODY, TRUE);
-          curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-          curl_setopt($ch, CURLOPT_FOLLOWLOCATION ,true);
-          curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
-          $result = curl_exec($ch);
-          $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-          $code = trim($code);
-          curl_close($ch);
-          if ($code[0] != '2') {
-            $errors['completion_url'] = E::ts('The completion URL does not belong to a valid page. Please check that an anonymous in user can access it.');
-          }
-        }
-      }
-    }
-    return $errors;
-  }
-
   /**
    * Get the fields/elements defined in this form.
    *

--- a/CRM/Gdpr/Form/CommunicationsPreferences.php
+++ b/CRM/Gdpr/Form/CommunicationsPreferences.php
@@ -259,6 +259,8 @@ class CRM_Gdpr_Form_CommunicationsPreferences extends CRM_Core_Form {
       $text_area_attributes
     );
 
+    $this->buildMailBlock();
+
     $this->addButtons(array(
       array(
         'type' => 'submit',
@@ -266,67 +268,34 @@ class CRM_Gdpr_Form_CommunicationsPreferences extends CRM_Core_Form {
         'isDefault' => TRUE,
       ),
     ));
-    $this->setDefaults($this->getDefaults());
     parent::buildQuickForm();
   }
 
   /**
-   * Gets public groups.
+   * Build Email Block
    */
-  function getGroups() {
-    if (!$this->groups) {
-      $groups = U::getGroups();
-      $this->groups = U::sortGroups($groups, array(
-        'group_enable' => 'desc',
-        'group_weight' => 'asc',
-        'group_title' => 'asc',
-      ));
-    }
-    return $this->groups;
+  public function buildMailBlock() {
+    $this->registerRule('emailList', 'callback', 'emailList', 'CRM_Utils_Rule');
+    $this->addYesNo('is_email_confirm', ts('Send Confirmation Email?'), NULL, NULL, ['onclick' => "return showHideByValue('is_email_confirm','','confirmEmail','block','radio',false);"]);
+    $this->add('textarea', 'confirm_email_text', ts('Text'));
+    $this->add('text', 'cc_confirm', ts('CC Confirmation To'));
+    $this->addRule('cc_confirm', ts('Please enter a valid list of comma delimited email addresses'), 'emailList');
+    $this->add('text', 'bcc_confirm', ts('BCC Confirmation To'));
+    $this->addRule('bcc_confirm', ts('Please enter a valid list of comma delimited email addresses'), 'emailList');
+    $this->add('text', 'confirm_from_name', ts('Confirm From Name'));
+    $this->add('text', 'confirm_from_email', ts('Confirm From Email'));
+    $this->addRule('confirm_from_email', ts('Email is not valid.'), 'email');
   }
 
-  public function postProcess() {
-    $values = $this->exportValues();
-    parent::postProcess();
-    $groupContainers = $this->groupContainerNames;
-    // Save values to settings except for groups.
-    $settingsElements = array_diff($this->getRenderableElementNames(), $groupContainers);
+  public function setDefaultValues() {
+    // Set some initial defaults
+    $defaults['is_email_confirm'] = 0;
 
-    // Purify HTML.
-    foreach ($values as $key => $value) {
-      $idx = !empty($this->_elementIndex[$key]) ? $this->_elementIndex[$key] : NULL;
-      if ($idx && !empty($this->_elements[$idx]->_type) && $this->_elements[$idx]->_type == 'textarea') { 
-        $values[$key] = CRM_Utils_String::purifyHTML($values[$key]);
-      }
-    }
-    
-    foreach ($settingsElements as $settingName) {
-      if (isset($values[$settingName])) {
-        $settings[$settingName] = $values[$settingName];
-      }
-    }
-    $groupSettings = array();
-    foreach ($groupContainers as $key) {
-      if (isset($values[$key])) {
-        $groupSettings[$key] = $values[$key];
-      }
-    }
-    $save = array(
-      U::SETTING_NAME => $settings,
-      U::GROUP_SETTING_NAME => $groupSettings,
-    );
-    U::saveSettings($save);
-    $url = CRM_Utils_System::url('civicrm/gdpr/dashboard', 'reset=1');
-    CRM_Core_Session::setStatus('Settings Saved.', 'GDPR', 'success');
-    CRM_Utils_System::redirect($url);
-    CRM_Utils_System::civiExit();
-  }
-
-  public function getDefaults() {
+    // Load defaults from settings
     $settings = U::getSettings();
     $key = U::SETTING_NAME;
     $group_key = U::GROUP_SETTING_NAME;
-    $form_defaults = array();
+    $defaults = array();
     $group_settings = $settings[$group_key] ? $settings[$group_key] : array();
     $groups = $this->getGroups();
     $map = array(
@@ -357,13 +326,64 @@ class CRM_Gdpr_Form_CommunicationsPreferences extends CRM_Core_Form {
     }
     // Flatten to fit the form structure.
     if (isset($settings[$key]) && isset($group_settings)) {
-      $form_defaults = array_merge($settings[$key], $group_settings);
+      $defaults = array_merge($settings[$key], $group_settings);
     }
-    return $form_defaults;
+    return $defaults;
   }
 
+  /**
+   * Gets public groups.
+   */
+  function getGroups() {
+    if (!$this->groups) {
+      $groups = U::getGroups();
+      $this->groups = U::sortGroups($groups, array(
+        'group_enable' => 'desc',
+        'group_weight' => 'asc',
+        'group_title' => 'asc',
+      ));
+    }
+    return $this->groups;
+  }
 
-  protected function getProfileOptions() {
+  public function postProcess() {
+    $values = $this->exportValues();
+    parent::postProcess();
+    $groupContainers = $this->groupContainerNames;
+    // Save values to settings except for groups.
+    $settingsElements = array_diff($this->getRenderableElementNames(), $groupContainers);
+
+    // Purify HTML.
+    foreach ($values as $key => $value) {
+      $idx = !empty($this->_elementIndex[$key]) ? $this->_elementIndex[$key] : NULL;
+      if ($idx && !empty($this->_elements[$idx]->_type) && $this->_elements[$idx]->_type == 'textarea') {
+        $values[$key] = CRM_Utils_String::purifyHTML($values[$key]);
+      }
+    }
+
+    foreach ($settingsElements as $settingName) {
+      if (isset($values[$settingName])) {
+        $settings[$settingName] = $values[$settingName];
+      }
+    }
+    $groupSettings = array();
+    foreach ($groupContainers as $key) {
+      if (isset($values[$key])) {
+        $groupSettings[$key] = $values[$key];
+      }
+    }
+    $save = array(
+      U::SETTING_NAME => $settings,
+      U::GROUP_SETTING_NAME => $groupSettings,
+    );
+    U::saveSettings($save);
+    $url = CRM_Utils_System::url('civicrm/gdpr/dashboard', 'reset=1');
+    CRM_Core_Session::setStatus('Settings Saved.', 'GDPR', 'success');
+    CRM_Utils_System::redirect($url);
+    CRM_Utils_System::civiExit();
+  }
+
+  public function getDefaults() {
 
   }
 

--- a/CRM/Gdpr/Form/UpdatePreference.php
+++ b/CRM/Gdpr/Form/UpdatePreference.php
@@ -18,20 +18,40 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
 
   public $containerPrefix = 'enable_';
 
-  //for Profile form validation
+  /**
+   * @var int the Contact ID
+   * @deprecated Use $this->getContactID and $this->_cid;
+   */
   public $_id;
+
+  /**
+   * @var int The contact ID
+   */
+  public $_cid;
+
   public $_gid;
   public $_context;
   public $_ruleGroupID;
 
+  public function getContactID() {
+    if (!empty($this->_cid)) {
+      $contactID = $this->_cid;
+    }
+    elseif (!empty($this->_id)) {
+      $contactID = $this->_id;
+    }
+    else {
+      $contactID = parent::getContactID();
+    }
+    $this->_cid = $this->_id = $contactID;
+    return $contactID;
+  }
+
   public function preProcess() {
     //Retrieve contact id from URL
-    $this->_cid = $this->getContactID();
-
-    //Do not allow anon users to update unless have a valid checksum
-    if(empty($this->_cid)){
-      //Do Nothing for now
-    }
+    if (empty($this->getContactID())) {
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+    };
 
     //Add Gdpr CSS file
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.vedaconsulting.gdpr', 'css/gdpr.css');
@@ -39,13 +59,12 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
   }
 
   public function getSettings() {
-    $this->settings    = U::getSettings();
+    $this->settings = U::getSettings();
     $this->commPrefSettings = $this->settings[U::SETTING_NAME];
     $this->commPrefGroupsetting   = $this->settings[U::GROUP_SETTING_NAME];
   }
 
   public function buildQuickForm() {
-
     //Get all Communication preference settings
     $this->getSettings();
     $this->_session = CRM_Core_Session::singleton();
@@ -213,20 +232,20 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
     }
   }
 
-  public static function formRule($fields, $files, $self){
+  public static function formRule($fields, $files, $form){
     $errors = array();
 
-    if (!empty($self->groupEleNames)) {
-      foreach ($self->groupEleNames as $groupName => $groupEleName) {
+    if (!empty($form->groupEleNames)) {
+      foreach ($form->groupEleNames as $groupName => $groupEleName) {
         //get the channel array and group channel array
         $groupChannelArray = array();
-        foreach ($self->channelEleNames as $channel) {
-          $groupChannel = str_replace($self->containerPrefix, '', $channel);
-          $channelSettingValue = $self->commPrefGroupsetting[$groupEleName][$groupChannel];
+        foreach ($form->channelEleNames as $channel) {
+          $groupChannel = str_replace($form->containerPrefix, '', $channel);
+          $channelSettingValue = $form->commPrefGroupsetting[$groupEleName][$groupChannel];
 
           if (!is_null($channelSettingValue) && $channelSettingValue != '') {
             $channelArray[$groupChannel] = ($fields[$channel] == 'YES') ? 1 : 0;
-            $groupChannelArray[$groupChannel] = empty($self->commPrefGroupsetting[$groupEleName][$groupChannel]) ? 0 : 1;
+            $groupChannelArray[$groupChannel] = empty($form->commPrefGroupsetting[$groupEleName][$groupChannel]) ? 0 : 1;
           }
         }
 
@@ -309,7 +328,7 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
     $emailPrimary = CRM_Utils_Request::retrieve('field_email', 'String', CRM_Core_DAO::$_nullObject);
     if ($emailPrimary) {
       $defaults['email-Primary'] = $emailPrimary;
-    }    
+    }
     return $defaults;
   }
 
@@ -320,12 +339,7 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
 
   public function postProcess() {
     $submittedValues = $this->exportValues();
-    $commPrefMapper  = U::getCommunicationPreferenceMapper();
-    //profile form validation will do dedupe and update id in $form
-    $existingContact = $this->_cid;
-    if (!empty($this->_id)) {
-      $existingContact = $this->_id;
-    }
+    $existingContact = $this->getContactID();
 
     $contactType = 'Individual';
     if ($existingContact) {
@@ -344,24 +358,24 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
     $termsConditionsField = $this->getTermsAndConditionFieldId();
     $tcFieldName  = 'custom_'.$termsConditionsField;
     if (!empty($submittedValues[$tcFieldName])) {
-      $acceptance = CRM_Gdpr_SLA_Utils::recordSLAAcceptance($contactID);
+      CRM_Gdpr_SLA_Utils::recordSLAAcceptance($contactID);
     }
 
     //we have now moved this section into common helper function which reused in other place like event/contribution thank you to let update comms preference using embed form.
-    U::updateCommsPrefByFormValues($contactID, $submittedValues);   
+    U::updateCommsPrefByFormValues($contactID, $submittedValues);
     U::createCommsPrefActivity($contactID, $submittedValues);
+
+    $this->sendConfirmation();
 
     if (!empty($this->commPrefSettings['completion_message'])) {
       $thankYouMsg = html_entity_decode($this->commPrefSettings['completion_message']);
-
-      //FIXME Redirect to Thank you page or destination url from setting
       CRM_Core_Session::setStatus($thankYouMsg, E::ts('Communication Preferences'), 'Success');
     }
 
     //Get the destination url from settings and redirect if we found one.
     if (!empty($this->commPrefSettings['completion_redirect'])) {
       $destinationURL = !empty($this->commPrefSettings['completion_url']) ? $this->commPrefSettings['completion_url'] : NULL;
-      //MV: commenting this line, We have already restriceted the setting to get only absoulte URl.
+      //MV: commenting this line, We have already restricted the setting to get only absolute URL.
       //check URL is not absolute and no leading slash then add leading slash before redirect.
       $parseURL = parse_url($destinationURL);
       if (empty($parseURL['host']) && (strpos($destinationURL, '/') !== 0)) {
@@ -370,6 +384,37 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
       CRM_Utils_System::redirect($destinationURL);
     }
     parent::postProcess();
+  }
+
+  public function sendConfirmation() {
+    if (empty($this->commPrefSettings['is_email_confirm'])) {
+      return;
+    }
+
+    $contactID = $this->getContactID();
+
+    list($displayName, $email) = CRM_Contact_BAO_Contact_Location::getEmailDetails($contactID);
+
+    $tplParams = [
+      'email' => $email,
+      'confirm_email_text' => CRM_Utils_Array::value('confirm_email_text', $this->commPrefSettings),
+      'display_name' => $displayName,
+    ];
+
+    $sendTemplateParams = [
+      'groupName' => 'msg_tpl_workflow_gdpr',
+      'valueName' => 'gdpr_update_preferences',
+      'contactId' => $contactID,
+      'tplParams' => $tplParams,
+    ];
+
+    $sendTemplateParams['from'] = CRM_Utils_Array::value('confirm_from_name', $this->commPrefSettings) . " <" . CRM_Utils_Array::value('confirm_from_email', $this->commPrefSettings) . ">";
+    $sendTemplateParams['toName'] = $displayName;
+    $sendTemplateParams['toEmail'] = $email;
+    $sendTemplateParams['autoSubmitted'] = TRUE;
+    $sendTemplateParams['cc'] = CRM_Utils_Array::value('cc_confirm', $this->commPrefSettings);
+    $sendTemplateParams['bcc'] = CRM_Utils_Array::value('bcc_confirm', $this->commPrefSettings);
+    CRM_Core_BAO_MessageTemplate::sendTemplate($sendTemplateParams);
   }
 
 

--- a/CRM/Gdpr/Form/UpdatePreference.php
+++ b/CRM/Gdpr/Form/UpdatePreference.php
@@ -68,8 +68,7 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
     }
 
     //Include reCAPTCHA?
-    $addCaptcha = $this->commPrefSettings['add_captcha'];
-    if ($addCaptcha) {
+    if ($addCaptcha = $this->commPrefSettings['add_captcha']) {
       $captcha = CRM_Utils_ReCAPTCHA::singleton();
       $captcha->add($this);
       $this->assign('isCaptcha', TRUE);

--- a/CRM/Gdpr/Form/UpdatePreference.php
+++ b/CRM/Gdpr/Form/UpdatePreference.php
@@ -50,7 +50,7 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
   public function preProcess() {
     //Retrieve contact id from URL
     if (empty($this->getContactID())) {
-      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
+      // Do nothing as we need anonymous users to be able to "update" their details
     };
 
     //Add Gdpr CSS file
@@ -67,10 +67,7 @@ class CRM_Gdpr_Form_UpdatePreference extends CRM_Core_Form {
   public function buildQuickForm() {
     //Get all Communication preference settings
     $this->getSettings();
-    $this->_session = CRM_Core_Session::singleton();
-    $userID  = $this->_session->get('userID');
-
-    // $this->assign('commPrefGroupsetting', $this->commPrefGroupsetting);
+    $userID = CRM_Core_Session::getLoggedInContactID();
 
     if (!empty($this->commPrefSettings['profile'])) {
       $this->buildCustom($this->commPrefSettings['profile']);

--- a/CRM/Gdpr/SLA/Utils.php
+++ b/CRM/Gdpr/SLA/Utils.php
@@ -131,17 +131,15 @@ EOT;
    * Records a contact accepting Terms and Conditions.
    */
   static function recordSLAAcceptance($contactId = NULL) {
-    $settings = self::getSettings();
-    $userID   = CRM_Core_Session::singleton()->getLoggedInContactID();
+    $userID = CRM_Core_Session::singleton()->getLoggedInContactID();
     $contactId = $contactId ? $contactId : $userID;
     if (!$contactId) {
       return;
     }
     $termsConditionsUrl = self::getTermsConditionsUrl();
     $termsConditionsField = self::getTermsConditionsField();
-    $termsConditionsFieldKey = 'custom_' . $termsConditionsField['id'];
     //MV 11Oct2018 Incase of offline Data policy acceptance, Update logged in user as source contact
-    $sourceContactID = $userID ? $userID : $contactId;    
+    $sourceContactID = $userID ? $userID : $contactId;
     $params = array(
       'source_contact_id' => $sourceContactID,
       'target_id' => $contactId,
@@ -150,7 +148,7 @@ EOT;
       'activity_type_id' => self::$activityTypeName,
       'custom_' . $termsConditionsField['id'] => $termsConditionsUrl,
     );
-    $result = civicrm_api3('Activity', 'create', $params);
+    civicrm_api3('Activity', 'create', $params);
   }
 
   static function isContactDueAcceptance($contactId = NULL) {

--- a/CRM/Gdpr/Upgrader.php
+++ b/CRM/Gdpr/Upgrader.php
@@ -13,8 +13,6 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
    * Example: Run an external SQL script when the module is installed.
    */
   public function install() {
-    //$this->executeSqlFile('sql/myinstall.sql');
-
     // Create 'GDPR Cancelled' membership status
     $this->createGDPRCancelledMembershipStatus();
   }
@@ -37,8 +35,6 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
    * Example: Run an external SQL script when the module is uninstalled.
    */
   public function uninstall() {
-    //$this->executeSqlFile('sql/myuninstall.sql');
-
     // Delete 'GDPR Cancelled' membership status
     $result = CRM_Gdpr_Utils::CiviCRMAPIWrapper('MembershipStatus', 'get', array(
       'sequential' => 1,
@@ -84,6 +80,8 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
         'is_active' => 1,
       ),
     ));
+
+    $this->addMsgTemplateGDPR();
   }
 
   /**
@@ -188,6 +186,11 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_1205() {
+    $this->ctx->log->info('Adding Update Communication Preferences MessageTemplate');
+    $this->addMsgTemplateGDPR();
+    return TRUE;
+  }
 
   /**
    * Example: Run an external SQL script when the module is uninstalled.
@@ -218,4 +221,84 @@ class CRM_Gdpr_Upgrader extends CRM_Gdpr_Upgrader_Base {
       $this->ctx->log->info($message);
     }
   }
+
+  private function addMsgTemplateGDPR() {
+    // Create msg_tpl_workflow_gdpr optiongroup
+    $existing = civicrm_api3('OptionGroup', 'get', [
+      'name' => "msg_tpl_workflow_gdpr",
+    ]);
+    if (empty($existing['count'])) {
+      $optionGroup = civicrm_api3('OptionGroup', 'create', [
+        'name' => "msg_tpl_workflow_gdpr",
+        'title' => "Message Template Workflow for GDPR",
+        'is_reserved' => 1,
+        'is_active' => 1,
+      ]);
+    }
+    else {
+      $optionGroup = CRM_Utils_Array::first($existing['values']);
+    }
+    // Create msg_tpl_workflow_gdpr optionvalue
+    $existing = civicrm_api3('OptionValue', 'get', [
+      'name' => "gdpr_update_preferences",
+    ]);
+    if (empty($existing['count'])) {
+      $optionValue = civicrm_api3('OptionValue', 'create', [
+        'name' => "gdpr_update_preferences",
+        'title' => "Update Communication Preferences",
+        'is_reserved' => 0,
+        'is_active' => 1,
+        'option_group_id' => $optionGroup['id'],
+      ]);
+    }
+    else {
+      $optionValue = CRM_Utils_Array::first($existing['values']);
+    }
+
+    // Create msg template
+    $msgTemplate = civicrm_api3('MessageTemplate', 'get', [
+      'workflow_id' => $optionValue['id'],
+    ]);
+    if (empty($msgTemplate['count'])) {
+      $msgTemplateParams = [
+        'msg_title' => 'Update Communication Preferences',
+        'msg_subject' => '{ts}You\'ve updated your communication preferences{/ts}',
+        'msg_text' => '{ts 1=$display_name}Dear %1{/ts},
+
+{if $confirm_email_text}{$confirm_email_text}
+{/if}
+
+{ts}Your communication preferences have been updated.{/ts}',
+        'msg_html' => '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title></title>
+<p>{capture assign=headerStyle}colspan=&quot;2&quot; style=&quot;text-align: left; padding: 4px; border-bottom: 1px solid #999; background-color: #eee;&quot;{/capture} {capture assign=labelStyle }style=&quot;padding: 4px; border-bottom: 1px solid #999; background-color: #f7f7f7;&quot;{/capture} {capture assign=valueStyle }style=&quot;padding: 4px; border-bottom: 1px solid #999;&quot;{/capture}</p>
+
+<center>
+<table border="0" cellpadding="0" cellspacing="0" id="crm-event_receipt" style="font-family: Arial, Verdana, sans-serif; text-align: left;" width="620"><!-- BEGIN HEADER --><!-- You can add table row(s) here with logo or other header elements --><!-- END HEADER --><!-- BEGIN CONTENT -->
+	<tbody>
+		<tr>
+			<td>
+			<p>{ts 1=$display_name}Dear %1{/ts},</p>
+			{if $confirm_email_text}<p>{$confirm_email_text|htmlize}</p>{/if}
+			<p>{ts}Your communication preferences have been updated.{/ts}</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+</center>',
+        'is_active' => 1,
+        'workflow_id' => $optionValue['id'],
+        'is_default' => 1,
+        'is_reserved' => 0,
+        'is_sms' => 0,
+      ];
+      // First we create the "current"
+      civicrm_api3('MessageTemplate', 'create', $msgTemplateParams);
+      // Now we create the "master"
+      $msgTemplateParams['is_default'] = 0;
+      $msgTemplateParams['is_reserved'] = 1;
+      civicrm_api3('MessageTemplate', 'create', $msgTemplateParams);
+    }
+  }
+
 }

--- a/gdpr.php
+++ b/gdpr.php
@@ -264,7 +264,7 @@ function gdpr_civicrm_buildForm($formName, $form) {
       );
 
       //amend communication preference link/embed form in thank you page
-      CRM_Gdpr_CommunicationsPreferences_Utils::commsPreferenceInThankyouPage($cid, $form, 'Event');  
+      CRM_Gdpr_CommunicationsPreferences_Utils::commsPreferenceInThankyouPage($cid, $form, 'Event');
     }
   }
   if ($formName == 'CRM_Contribute_Form_Contribution_Main') {
@@ -497,8 +497,8 @@ function gdpr_civicrm_navigationMenu( &$params ) {
  * implementation of hook_civicrm_token
  */
 function gdpr_civicrm_tokens( &$tokens ){
-  //Keeping this token only to sustain the old tokens otherwise, 
-  //the token 'CommunicationPreferences' can be used in all places  
+  //Keeping this token only to sustain the old tokens otherwise,
+  //the token 'CommunicationPreferences' can be used in all places
   $tokens['contact']['contact.comm_pref_supporter_url'] = E::ts("Communication Preferences URL");
   $tokens['contact']['contact.comm_pref_supporter_link'] = E::ts("Communication Preferences Link");
   $tokens['CommunicationPreferences'] = array(
@@ -515,20 +515,20 @@ function gdpr_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(
     /*
     THIS CHANGE IS ONLY FOR ACTIONSCHEDULE (SEND EMAIL USING SCHEDULE REMINDER)
 
-    we have mentioned the contact custom tokens in token hook. 
-    so whenever replaceHookToken called its trying replace Category 'Contact' tokens 
+    we have mentioned the contact custom tokens in token hook.
+    so whenever replaceHookToken called its trying replace Category 'Contact' tokens
     (which cause null values in template result).
 
-    This is not happening when send email via contact summary or mailing, 
-    because all other work flow to send emails are builds the contact details array 
+    This is not happening when send email via contact summary or mailing,
+    because all other work flow to send emails are builds the contact details array
     before replaceHookToken fired using this function CRM_Utils_Token::getTokenDetails().
-    
-    When Action schedule send email, Contact Details get from BAO API Query 
-    which doesn't return some default contact values ex: email_greetings, 
+
+    When Action schedule send email, Contact Details get from BAO API Query
+    which doesn't return some default contact values ex: email_greetings,
     postal greetings etc. So build the contact details array with all default values.
-    
-    This changes is needed only when we have $tokens['contact']. Keeping this oly to sustain 
-    the old token. 
+
+    This changes is needed only when we have $tokens['contact']. Keeping this oly to sustain
+    the old token.
     IN FUTURE or V3.0, WE CAN REMOVE THIS CHANGE ALONG WITH CONTACT CUSTOM TOKEN ABOVE.
     */
     $tokenValues = array();
@@ -561,40 +561,30 @@ function gdpr_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(
 function gdpr_civicrm_summaryActions( &$actions, $contactID ) {
   $actions['comm_pref'] = array(
     'title' => 'Communication Preferences Link',
-    //need a weight parameter here, Contact BAO looking for weight key and returning notice message. 
-    'weight' => 60, 
+    //need a weight parameter here, Contact BAO looking for weight key and returning notice message.
+    'weight' => 60,
     'ref' => 'comm_pref',
     'key' => 'comm_pref',
     'href' => CRM_Gdpr_CommunicationsPreferences_Utils::getCommPreferenceURLForContact($contactID, TRUE),
-  );  
+  );
 }
 
 function gdpr_civicrm_permission(&$permissions) {
-  $prefix = E::ts('GDPR') . ': ';
-  $version = CRM_Utils_System::version();
-  if (version_compare($version, '4.6.1') >= 0) {
-    $permissions += array(
-      'access GDPR' => array(
-        $prefix . E::ts('access GDPR'),
-        E::ts('View GDPR related information'),
-      ),
-      'forget contact' => array(
-        $prefix . E::ts('forget contact'),
-        E::ts('Anonymize contacts'),
-      ),
-      'administer GDPR' => array(
-        $prefix . E::ts('administer GDPR'),
-        E::ts('Manage GDPR settings'),
-      ),
-    );
-  }
-  else {
-    $permissions += array(
-      'access GDPR' => $prefix . E::ts('access GDPR'),
-      'forget contact' => $prefix . E::ts('forget contact'),
-      'administer GDPR' => $prefix . E::ts('administer GDPR'),
-    );
-  }
+  $prefix = E::ts('CiviGDPR') . ': ';
+  $permissions += array(
+    'access GDPR' => array(
+      $prefix . E::ts('access GDPR'),
+      E::ts('View GDPR related information'),
+    ),
+    'forget contact' => array(
+      $prefix . E::ts('forget contact'),
+      E::ts('Anonymize contacts'),
+    ),
+    'administer GDPR' => array(
+      $prefix . E::ts('administer GDPR'),
+      E::ts('Manage GDPR settings'),
+    ),
+  );
 }
 
 /**

--- a/info.xml
+++ b/info.xml
@@ -14,13 +14,12 @@
     <url desc="Support">https://vedaconsulting.co.uk</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate>2018-12-14</releaseDate>
-  <version>2.7</version>
+  <releaseDate>2019-10-14</releaseDate>
+  <version>2.8</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>5.13</ver>
   </compatibility>
-  <comments>This extension is under active development, with the up and coming GDPR implementation date of the 25th of May we're expecting a lot of activity on the extension.</comments>
   <civix>
     <namespace>CRM/Gdpr</namespace>
   </civix>

--- a/info.xml
+++ b/info.xml
@@ -18,9 +18,7 @@
   <version>2.7</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.6</ver>
-    <ver>4.7</ver>
-    <ver>5.0</ver>
+    <ver>5.13</ver>
   </compatibility>
   <comments>This extension is under active development, with the up and coming GDPR implementation date of the 25th of May we're expecting a lot of activity on the extension.</comments>
   <civix>

--- a/templates/CRM/Gdpr/Form/CommunicationsPreferences.tpl
+++ b/templates/CRM/Gdpr/Form/CommunicationsPreferences.tpl
@@ -151,6 +151,62 @@
     </div>
     <div class="clear"></div>
   </div> {* end Completion block *}
+    {* Confirmation Email Block *}
+  <fieldset id="mail" class="crm-collapsible {if $defaultsEmpty}collapsed{/if}">
+    <legend class="collapsible-title">{ts}Confirmation Email{/ts}</legend>
+    <div>
+      <table class="form-layout-compressed">
+        <tr class="crm-event-manage-registration-form-block-is_email_confirm">
+          <td scope="row" class="label" width="20%">{$form.is_email_confirm.label}</td>
+          <td>{$form.is_email_confirm.html}<br/>
+            <span
+                    class="description">{ts}Do you want a confirmation email sent automatically to the user?{/ts}</span>
+          </td>
+        </tr>
+      </table>
+      <div id="confirmEmail">
+        <table class="form-layout-compressed">
+          <tr class="crm-event-manage-registration-form-block-confirm_email_text">
+            <td scope="row" class="label"
+                width="20%">{$form.confirm_email_text.label} {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_email_text' id=$eventID}{/if}</td>
+            <td>{$form.confirm_email_text.html}<br/>
+              <span
+                      class="description">{ts}Additional message or instructions to include in confirmation email.{/ts}</span>
+            </td>
+          </tr>
+          <tr class="crm-event-manage-registration-form-block-confirm_from_name">
+            <td scope="row" class="label" width="20%">{$form.confirm_from_name.label} <span
+                      class="crm-marker">*</span> {if $action == 2}{include file='CRM/Core/I18n/Dialog.tpl' table='civicrm_event' field='confirm_from_name' id=$eventID}{/if}
+            </td>
+            <td>{$form.confirm_from_name.html}<br/>
+              <span class="description">{ts}FROM name for email.{/ts}</span>
+            </td>
+          </tr>
+          <tr class="crm-event-manage-registration-form-block-confirm_from_email">
+            <td scope="row" class="label" width="20%">{$form.confirm_from_email.label} <span class="crm-marker">*</span></td>
+            <td>{$form.confirm_from_email.html}<br/>
+              <span
+                      class="description">{ts}FROM email address (this must be a valid email account with your SMTP email service provider).{/ts}</span>
+            </td>
+          </tr>
+          <tr class="crm-event-manage-registration-form-block-cc_confirm">
+            <td scope="row" class="label" width="20%">{$form.cc_confirm.label}</td>
+            <td>{$form.cc_confirm.html}<br/>
+              <span
+                      class="description">{ts}You may specify one or more email addresses to receive a carbon copy (cc). Multiple email addresses should be separated by a comma (e.g. jane@example.org, paula@example.org).{/ts}</span>
+            </td>
+          </tr>
+          <tr class="crm-event-manage-registration-form-block-bcc_confirm">
+            <td scope="row" class="label" width="20%">{$form.bcc_confirm.label}</td>
+            <td>{$form.bcc_confirm.html}<br/>
+              <span
+                      class="description">{ts}You may specify one or more email addresses to receive a blind carbon copy (bcc) of the confirmation email. Multiple email addresses should be separated by a comma (e.g. jane@example.org, paula@example.org).{/ts}</span>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </fieldset>
  </div>{* end form *}
 
 {* FOOTER *}
@@ -224,3 +280,12 @@
 </script>
 {/literal}
 {/crmScope}
+
+{include file="CRM/common/showHideByFieldValue.tpl"
+trigger_field_id    ="is_email_confirm"
+trigger_value       =""
+target_element_id   ="confirmEmail"
+target_element_type ="block"
+field_type          ="radio"
+invert              = 0
+}

--- a/templates/CRM/Gdpr/Form/UpdatePreference.tpl
+++ b/templates/CRM/Gdpr/Form/UpdatePreference.tpl
@@ -11,7 +11,7 @@
 		{/if}
 
 		{if !empty($form.activity_source)}
-		<fieldset>
+		<fieldset id="crm-communications-preferences-groups">
 			<div class="crm-section">
 				<div class="label">{$form.activity_source.label}</div>
 				<div class="content">{$form.activity_source.html}</div>
@@ -21,7 +21,7 @@
 
 		<!-- if any profile has configured -->
 		{if !empty($custom_pre)}
-		<fieldset>
+		<fieldset id="crm-communications-preferences-profile">
 		    <div class="crm-public-form-item crm-group custom_pre_profile-group">
 		    {include file="CRM/UF/Form/Block.tpl" fields=$custom_pre}
 		    </div>
@@ -29,8 +29,11 @@
 		{/if}
 
 		<!-- Channels fieldset section -->
-		<fieldset>
+		{if $channelEleNames}
+		<fieldset id="crm-communications-preferences-channels">
+			{if $channels_intro}
 			<legend>{$channels_intro}</legend>
+			{/if}
 			{foreach from=$channelEleNames item=elementName}
 			  <div class="crm-section">
 			    <div class="label">{$form.$elementName.label}</div>
@@ -39,14 +42,18 @@
 			  </div>
 			{/foreach}
 		</fieldset>
+		{/if}
 	</div>
 
 	<!-- Groups from settings -->
 	<div class="comm-pref-block groups-block">
 
+		{if $groupEleNames}
 		<!-- Groups Fieldset -->
-		<fieldset class="groups-fieldset">
+		<fieldset id="crm-communications-preferences-groups" class="groups-fieldset">
+			{if $groups_heading}
 			<legend>{$groups_heading}</legend>
+			{/if}
       {if $groups_intro}
       <div class="section-description">
         {ts}{$groups_intro}{/ts}
@@ -77,10 +84,11 @@
 			  </div>
 			{/foreach}
 		</fieldset>
+		{/if}
 
 	<div class="clear"></div>
 		<!-- GDPR Terms and conditions url link and checkbox -->
-    <fieldset class="data-policy-fieldset">
+    <fieldset id="crm-communications-preferences-datapolicy" class="data-policy-fieldset">
 		{if $isContactDueAcceptance}
       <div class="data-policy-intro section-sescription">
           {$tcIntro}

--- a/templates/CRM/Gdpr/Page/ContactSummary.tpl
+++ b/templates/CRM/Gdpr/Page/ContactSummary.tpl
@@ -1,7 +1,7 @@
-<div id="last_acceptance_date" class="crm-summary-row">
+<div id="last_acceptance_date" class="crm-summary-row" style="display: none;">
   <div class="crm-label">{ts}GDPR Status{/ts}</div>
   <div class="crm-content crm-contact-gdpr_status">
-		{if $lastAcceptanceDate} 
+		{if $lastAcceptanceDate}
 			Communication preferences submitted on {$lastAcceptanceDate}
 		{/if}
 	</div>
@@ -9,7 +9,10 @@
 {literal}
 <script type="text/javascript">
 	CRM.$(function($){
-		$('#last_acceptance_date').prependTo('#crm-communication-pref-content .crm-inline-block-content');
+		if ($('#crm-communication-pref-content').length !== 0) {
+			$('#last_acceptance_date').prependTo('#crm-communication-pref-content .crm-inline-block-content');
+			$('#last_acceptance_date').show();
+		}
 	});
 </script>
 {/literal}

--- a/xml/Menu/gdpr.xml
+++ b/xml/Menu/gdpr.xml
@@ -58,7 +58,7 @@
     <path>civicrm/gdpr/comms-prefs/update</path>
     <page_callback>CRM_Gdpr_Form_UpdatePreference</page_callback>
     <title>UpdatePreference</title>
-    <is_public>1</is_public>
+    <is_public>true</is_public>
     <access_callback>1</access_callback>
     <weight>0</weight>
   </item>


### PR DESCRIPTION
* Remove validation of redirect link as it stops you configuring a URL if you are using a test site behind basic auth etc (as it's not accessible)
* Fix php notices, cleanup comms preferences form
* Add option to send an email confirmation when updating communication preferences
* Fix permissions on update prefs for anonymous
* Don't try and add 'GDPR status' to contact summary if we're using contact layout and section is not present.