### PR TITLE
Clairfy installation process re permissions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,6 +15,13 @@ Use the following steps to install GDPR.
     * GDPR should show up as green-highlighted.
     * The option to **Disable** it will be present.
 
+1. Next grant appropriate permissions (see below)
+
+## Permissions {:#permissions}
+
+The GDPR extension adds 3 new permissions which should be configured within your CMS before the extension can be used.
+See [Permissions and access control](https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control) the CiviCRM User Guide for more information.
+
 
 ## Discovering features after installing {:#discovery}
 
@@ -24,12 +31,6 @@ After installing, GDPR’s features can be found in the following places:
 * A GDPR tab within a contacts record
 
 You will need to complete the GDPR settings in the GDPR dashboard.
-
-## Permissions {:#permissions}
-
-The GDPR extension adds 3 new permissions which should be configured within your CMS before the extension can be used.
-See [Permissions and access control](https://docs.civicrm.org/user/en/latest/initial-set-up/permissions-and-access-control) the CiviCRM User Guide for more information.
-
 
 ## Removing
 


### PR DESCRIPTION
I experienced a papercut with installing - the existing instructions have a list of steps to install (all normal) which are then followed by text telling me to expect to see GDPR in the contacts menu.

I did not see that, so thought installation had failed, when in fact the next section says about permissions.

I've moved the permissions bit above the discovery section, and added the permissions as another step to the installation instructions. I hope this will make it easier to follow.