### PR TITLE
Prevent warning: Invalid argument supplied for foreach

### DIFF
--- a/gdpr.php
+++ b/gdpr.php
@@ -538,6 +538,7 @@ function gdpr_civicrm_tokenValues(&$values, $cids, $job = null, $tokens = array(
     the old token.
     IN FUTURE or V3.0, WE CAN REMOVE THIS CHANGE ALONG WITH CONTACT CUSTOM TOKEN ABOVE.
     */
+    if (is_null($cids) ) { $cids = array(); }
     $tokenValues = array();
     if ($context == 'CRM_Core_BAO_ActionSchedule') {
       list($tokenValues) = CRM_Utils_Token::getTokenDetails($cids,


### PR DESCRIPTION
In some cases, CiviCRM triggers the `tokenValues` hook with the **$cids** set to null. With this patch, we prevent a *PHP Warning:  Invalid argument supplied for foreach()*.