### PR TITLE
unconditionally assign lastAcceptanceDate

### DIFF
--- a/gdpr.php
+++ b/gdpr.php
@@ -531,8 +531,8 @@ function gdpr_civicrm_pageRun(&$page) {
     $accept_date = NULL;
     if (!empty($accept_activity['activity_date_time'])) {
       $accept_date = date('d/m/Y', strtotime($accept_activity['activity_date_time']));
-      $page->assign('lastAcceptanceDate', $accept_date);
     }
+    $page->assign('lastAcceptanceDate', $accept_date);
   }
   if ($pageName == 'CRM_Event_Page_EventInfo') {
     CRM_Core_Resources::singleton()->addStyleFile('uk.co.vedaconsulting.gdpr', 'css/gdpr.css');


### PR DESCRIPTION
In PHP 8, Smarty throws warnings if you attempt to access an unassigned variable.  I've been seeing this in my logs:
```
Message 	Warning: Undefined array key "lastAcceptanceDate" in include() (line 8 of /tmp/civicrm/templates_c/en_US/%%27/271/2713A10B%%ContactSummary.tpl.php) 
```

Since we're already assigning a value of `NULL` a few lines above, we should always be assigning that to Smarty instead of leaving it uninitialized.